### PR TITLE
fix: install `chrome` dependencies

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -29,13 +29,39 @@ jobs:
         with:
           deno-version: v2.x
 
+      - name: Install Chrome dependencies
+        if: github.ref == 'refs/heads/main'
+        run: |
+          sudo apt install -y --no-install-recommends \
+            libnss3 \
+            libdbus-1-3 \
+            libatk1.0-0 \
+            libasound2t64 \
+            libxrandr2 \
+            libxkbcommon-dev \
+            libxfixes3 \
+            libxcomposite1 \
+            libxdamage1 \
+            libgbm-dev \
+            libatk-bridge2.0-0 \
+            binutils \
+            libglib2.0-0 \
+            libgdk-pixbuf2.0-0 \
+            libgtk-3-0 \
+            libnss3-dev \
+            libxss-dev \
+            xvfb \
+            fonts-liberation \
+            libu2f-udev \
+            xdg-utils
+
       - name: Setup Chrome
         uses: ./external/setup-chrome
         if: github.ref == 'refs/heads/main'
         id: setup-chrome
         with:
           chrome-version: stable
-          install-dependencies: true
+          install-dependencies: false
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/coverage.yaml` file to improve the setup process for Chrome dependencies. The most important changes include adding a step to install necessary Chrome dependencies and modifying the existing setup to avoid redundant installations.

Improvements to Chrome setup:

* [`.github/workflows/coverage.yaml`](diffhunk://#diff-3d92b123fe211c36c9df8e06231e1f9f6078331c717fedf2f8396bf31240df1fR32-R64): Added a new step to install Chrome dependencies only if the branch is `main`. This ensures that the required libraries are available for Chrome to run correctly.
* [`.github/workflows/coverage.yaml`](diffhunk://#diff-3d92b123fe211c36c9df8e06231e1f9f6078331c717fedf2f8396bf31240df1fR32-R64): Modified the `Setup Chrome` step to skip installing dependencies, as they are now installed in a separate step. This prevents redundant installations and speeds up the workflow.