### PR TITLE
add: new project branding under `frostc`

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -78,7 +78,7 @@ jobs:
 
       - name: Generate coverage report
         run: |
-          hpc-codecov cabal:glados-test --exclude Main,Paths_glados --out codecov.json --format codecov --verbose
+          hpc-codecov cabal:frostc-test --exclude Main,Paths_frostc --out codecov.json --format codecov --verbose
 
       - name: Publish coverage report to Discord
         if: github.ref == 'refs/heads/main'
@@ -95,7 +95,7 @@ jobs:
         if: github.ref == 'refs/heads/main'
         run: |
           cabal haddock --haddock-html --haddock-hyperlink-source --haddock-quickjump
-          echo "DOCS_DIR=$(find dist-newstyle/build -type d -path '*/doc/html/glados' | head -n 1)" >> $GITHUB_ENV
+          echo "DOCS_DIR=$(find dist-newstyle/build -type d -path '*/doc/html/frostc' | head -n 1)" >> $GITHUB_ENV
   
       - name: Deploy Haddock to GitHub Pages
         uses: ./external/actions-gh-pages

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,8 +38,8 @@ jobs:
 
       - name: Get binary path
         run: |
-          mv "$(cabal list-bin exe:glados)" "$(cabal list-bin exe:glados)_$(uname -s)_$(uname -m)"
-          echo "GLADOS_BIN=$(cabal list-bin exe:glados)_$(uname -s)_$(uname -m)" >> $GITHUB_ENV
+          mv "$(cabal list-bin exe:frostc)" "$(cabal list-bin exe:frostc)_$(uname -s)_$(uname -m)"
+          echo "GLADOS_BIN=$(cabal list-bin exe:frostc)_$(uname -s)_$(uname -m)" >> $GITHUB_ENV
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
-PROJECT_NAME := glados
+PROJECT_NAME := frostc
 BUILD_DIR := dist-newstyle
 EXECUTABLE := $(PROJECT_NAME)
 
-BUILD_OUTPUT := $(shell cabal list-bin exe:glados)
+BUILD_OUTPUT := $(shell cabal list-bin exe:frostc)
 
 COLOR_RESET := \033[0m
 COLOR_BLUE := \033[1;34m

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -56,8 +56,8 @@ optionsInfo =
   O.info
     (O.helper <*> optionsParser)
     ( O.fullDesc
-        <> O.progDesc "Compile FrostLang source code to LLVM IR"
-        <> O.header "FrostLang Compiler"
+        <> O.progDesc "Compile Frost source code to LLVM Intermediate Representation"
+        <> O.header "The Frost Programming Language Compiler"
     )
 
 compile :: String -> String -> Bool -> E.ExceptT CompileError IO String

--- a/docs/book.json
+++ b/docs/book.json
@@ -1,6 +1,6 @@
 {
-  "title": "FrostLang HandBook",
-  "description": "Developer Cheat Sheet for the FrostLang Programming Language",
+  "title": "The Frost Programming Language Handbook",
+  "description": "Developer Cheat Sheet for the the Frost Programming Language",
   "plugins": [
     "code",
     "search",

--- a/docs/developer-manual/contributing/building-from-source.md
+++ b/docs/developer-manual/contributing/building-from-source.md
@@ -21,7 +21,7 @@ Before you begin, ensure you have the following tools installed:
    Clone the Frost repository and initialize its submodules:
 
    ```bash
-   git clone --recursive https://github.com/Jabolol/glados.git
+   git clone --recursive https://github.com/Jabolol/frost.git
    cd frost
    ```
 
@@ -68,7 +68,7 @@ Before you begin, ensure you have the following tools installed:
 
 We maintain Haddock documentation for the Frost compiler. It is currently hosted
 on GitHub Pages and can be accessed at
-[https://jabolol.github.io/glados/](https://jabolol.github.io/glados/).
+[https://jabolol.github.io/frost/](https://jabolol.github.io/frost/).
 
 To generate the documentation locally, run the following command:
 

--- a/docs/user-manual/getting-started.md
+++ b/docs/user-manual/getting-started.md
@@ -9,7 +9,7 @@ journey with Frost programming. Currently available for `Linux` (x86_64) and
 
 **Download and Install**
 
-1. Navigate to the [releases page](https://github.com/Jabolol/glados/releases/)
+1. Navigate to the [releases page](https://github.com/Jabolol/frost/releases/)
 2. Download the latest version for your operating system
 3. Extract the archive to your preferred location
 4. Add the `frostc` binary to your system's PATH
@@ -85,7 +85,7 @@ Save it as `hello.ff` and use
 program:
 
 ```bash
-./frostc -i hello.ff -o hello.ll | lli
+frostc -i hello.ff -o hello.ll | lli
 ```
 
 ## Next Steps

--- a/examples/README.md
+++ b/examples/README.md
@@ -39,7 +39,7 @@ run the LLVM IR. For example, to run the Mandelbrot set example, you can run the
 following commands:
 
 ```sh
-$ ./glados -i mandelbrot.ff -o mandelbrot.ll
+$ frostc -i mandelbrot.ff -o mandelbrot.ll
 ```
 
 > [!TIP]
@@ -91,7 +91,7 @@ Have a look at [`echo.ff`](echo.ff) for the acutal implementation
 2. Compile the program
 
 ```sh
-$ ./glados -i echo.ff -o echo.ll
+$ frostc -i echo.ff -o echo.ll
 ```
 
 3. Run the server
@@ -125,7 +125,7 @@ sum: int int -> int = a b {
 2. Compile the `sum.ff` file to LLVM IR:
 
 ```sh
-$ ./glados -i sum.ff -o sum.ll
+$ frostc -i sum.ff -o sum.ll
 ```
 
 #### Embedding in `C`

--- a/glados.cabal
+++ b/glados.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.4
-name: glados
+name: frostc
 version: 1.0.0.0
-synopsis: Generic Language and Data Operand Syntax
+synopsis: The Frost Programming Language Compiler
 license: MIT
 license-file: LICENSE
 author: Javier R
@@ -12,7 +12,7 @@ extra-doc-files: README.md
 
 source-repository head
   type: git
-  location: git@github.com:EpitechPromo2027/B-FUN-500-BAR-5-2-glados-oriol.linan.git
+  location: git@github.com:Jabolol/frost.git
 
 common warnings
   ghc-options:
@@ -64,13 +64,13 @@ library
   hs-source-dirs: lib
   default-language: Haskell2010
 
-executable glados
+executable frostc
   import: warnings
   main-is: Main.hs
   build-depends:
     base ^>=4.17.2.1,
     filepath >=1.4.2 && <1.5,
-    glados,
+    frostc,
     llvm-hs-pretty >=0.9.0 && <0.10,
     optparse-applicative >=0.18.1 && <0.19,
     pretty-simple >=4.1.2 && <4.2,
@@ -80,7 +80,7 @@ executable glados
   hs-source-dirs: app
   default-language: Haskell2010
 
-test-suite glados-test
+test-suite frostc-test
   import: warnings
   default-language: Haskell2010
   type: exitcode-stdio-1.0
@@ -110,7 +110,7 @@ test-suite glados-test
     QuickCheck,
     base ^>=4.17.2.1,
     bytestring >=0.11.2 && <0.12,
-    glados,
+    frostc,
     hspec,
     hspec-discover,
     llvm-hs-pure >=9.0.0 && <9.1,


### PR DESCRIPTION
This pull request includes several changes to rename the project from "glados" to "frostc" across various files and documentation. Below are the most important changes grouped by theme:

### Workflow and Configuration Updates:
* [`.github/workflows/coverage.yaml`](diffhunk://#diff-3d92b123fe211c36c9df8e06231e1f9f6078331c717fedf2f8396bf31240df1fL81-R81): Updated coverage report generation and documentation paths to use "frostc" instead of "glados". [[1]](diffhunk://#diff-3d92b123fe211c36c9df8e06231e1f9f6078331c717fedf2f8396bf31240df1fL81-R81) [[2]](diffhunk://#diff-3d92b123fe211c36c9df8e06231e1f9f6078331c717fedf2f8396bf31240df1fL98-R98)
* [`.github/workflows/release.yaml`](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL41-R42): Modified binary path and environment variable to reflect the new project name "frostc".
* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L1-R5): Changed `PROJECT_NAME` and related variables from "glados" to "frostc".

### Source Code and Build System:
* [`glados.cabal`](diffhunk://#diff-466d22dbf2f81d7207130727ef88d8ec1e8711b1f397f651422993175eeffa73L2-R4): Renamed the project to "frostc" and updated related fields and dependencies. [[1]](diffhunk://#diff-466d22dbf2f81d7207130727ef88d8ec1e8711b1f397f651422993175eeffa73L2-R4) [[2]](diffhunk://#diff-466d22dbf2f81d7207130727ef88d8ec1e8711b1f397f651422993175eeffa73L15-R15) [[3]](diffhunk://#diff-466d22dbf2f81d7207130727ef88d8ec1e8711b1f397f651422993175eeffa73L67-R73) [[4]](diffhunk://#diff-466d22dbf2f81d7207130727ef88d8ec1e8711b1f397f651422993175eeffa73L83-R83) [[5]](diffhunk://#diff-466d22dbf2f81d7207130727ef88d8ec1e8711b1f397f651422993175eeffa73L113-R113)
* [`app/Main.hs`](diffhunk://#diff-d3e498a88b4c374b1edbd8693542a73e944d51a24a64a683658926ba655bc6ffL59-R60): Updated program description and header to reflect the new project name.

### Documentation Updates:
* [`docs/book.json`](diffhunk://#diff-216cd3c385acac88723fefbd039494281eb7ca798750db0fcf1ba79a2a55aa2aL2-R3): Updated the title and description to "The Frost Programming Language Handbook".
* [`docs/developer-manual/contributing/building-from-source.md`](diffhunk://#diff-d4d0242b9474217c45d7b6012d31ec264448be1ca60bb52044bc480c816ff8bcL24-R24): Changed repository URLs and documentation links to "frost". [[1]](diffhunk://#diff-d4d0242b9474217c45d7b6012d31ec264448be1ca60bb52044bc480c816ff8bcL24-R24) [[2]](diffhunk://#diff-d4d0242b9474217c45d7b6012d31ec264448be1ca60bb52044bc480c816ff8bcL71-R71)
* [`docs/user-manual/getting-started.md`](diffhunk://#diff-ce0b932e3559d83bb50ef9ef8faef4ff839ce5d2d7e56f5205b43d970f8c8540L12-R12): Updated references to the releases page and binary usage examples to "frost". [[1]](diffhunk://#diff-ce0b932e3559d83bb50ef9ef8faef4ff839ce5d2d7e56f5205b43d970f8c8540L12-R12) [[2]](diffhunk://#diff-ce0b932e3559d83bb50ef9ef8faef4ff839ce5d2d7e56f5205b43d970f8c8540L88-R88)
* [`examples/README.md`](diffhunk://#diff-49aaa2819e35a856818ecec8c9fa7e1c79ad028d3f44bd749736353cfb51bac9L42-R42): Modified example commands to use "frostc" instead of "glados". [[1]](diffhunk://#diff-49aaa2819e35a856818ecec8c9fa7e1c79ad028d3f44bd749736353cfb51bac9L42-R42) [[2]](diffhunk://#diff-49aaa2819e35a856818ecec8c9fa7e1c79ad028d3f44bd749736353cfb51bac9L94-R94) [[3]](diffhunk://#diff-49aaa2819e35a856818ecec8c9fa7e1c79ad028d3f44bd749736353cfb51bac9L128-R128)